### PR TITLE
Use "\n" as a delimiter for RTF segments.

### DIFF
--- a/src/ScintillaNET/Helpers.cs
+++ b/src/ScintillaNET/Helpers.cs
@@ -599,7 +599,7 @@ namespace ScintillaNET
                                 // NOTE: We don't support StyleData.Visible and StyleData.Case in RTF
 
                                 lastStyle = style;
-                                tw.Write(" "); // Delimiter
+                                tw.Write("\n"); // Delimiter
                             }
 
                             switch (ch)


### PR DESCRIPTION
Explanation: A space character is meaningless only if it’s the optional meaningless space at the end of a command. Otherwise, every space character means to insert a space character! A newline (or 2 or 15) doesn’t indicated a linebreak. ( RTF Pocket Guide by Sean M. Burke https://www.oreilly.com/library/view/rtf-pocket-guide/9781449302047/ch01.html)