### PR TITLE
Added support for setting the caret and the selection layer

### DIFF
--- a/Scintilla.NET/Scintilla.NET.csproj
+++ b/Scintilla.NET/Scintilla.NET.csproj
@@ -100,6 +100,9 @@
 		<Compile Include="..\Shared\IndicatorReleaseEventArgs.cs" Link="IndicatorReleaseEventArgs.cs" />
 		<Compile Include="..\Shared\IndicatorStyle.cs" Link="IndicatorStyle.cs" />
 		<Compile Include="..\Shared\InsertCheckEventArgs.cs" Link="InsertCheckEventArgs.cs" />
+		<Compile Include="..\Shared\Layer.cs">
+		  <Link>Layer.cs</Link>
+		</Compile>
 		<Compile Include="..\Shared\Lexer.cs" Link="Lexer.cs" />
 		<Compile Include="..\Shared\Line.cs" Link="Line.cs" />
 		<Compile Include="..\Shared\LineCollection.cs" Link="LineCollection.cs" />

--- a/Shared/Layer.cs
+++ b/Shared/Layer.cs
@@ -1,0 +1,23 @@
+namespace ScintillaNET;
+
+/// <summary>
+/// 
+/// </summary>
+public enum Layer
+{
+	/// <summary>
+	/// Draw the selection background opaquely on the base layer.
+	/// </summary>
+	Base = NativeMethods.SC_LAYER_BASE,
+
+	/// <summary>
+	/// Draw the selection background translucently under the text. This will not work in single phase drawing mode
+	/// (<see cref="Phases.One"/>) as there is no under-text phase.
+	/// </summary>
+	UnderText = NativeMethods.SC_LAYER_UNDER_TEXT,
+
+	/// <summary>
+	/// Draw the selection background translucently over the text.
+	/// </summary>
+	OverText = NativeMethods.SC_LAYER_OVER_TEXT
+}

--- a/Shared/Layer.cs
+++ b/Shared/Layer.cs
@@ -1,7 +1,7 @@
 namespace ScintillaNET;
 
 /// <summary>
-/// 
+/// The layer on which a <see cref="Scintilla"/> control will draw elements like for example the text selection.
 /// </summary>
 public enum Layer
 {
@@ -11,7 +11,7 @@ public enum Layer
 	Base = NativeMethods.SC_LAYER_BASE,
 
 	/// <summary>
-	/// Draw the selection background translucently under the text. This will not work in single phase drawing mode
+	/// Draw the selection background translucently under the text. This will not work in single phase drawing mode.
 	/// (<see cref="Phases.One"/>) as there is no under-text phase.
 	/// </summary>
 	UnderText = NativeMethods.SC_LAYER_UNDER_TEXT,

--- a/Shared/NativeMethods.cs
+++ b/Shared/NativeMethods.cs
@@ -177,6 +177,11 @@ internal static class NativeMethods
     // Line end type
     public const int SC_LINE_END_TYPE_DEFAULT = 0;
     public const int SC_LINE_END_TYPE_UNICODE = 1;
+    
+    //Line layers
+    public const int SC_LAYER_BASE = 0;
+    public const int SC_LAYER_UNDER_TEXT = 1;
+    public const int SC_LAYER_OVER_TEXT = 2;
 
     // Margins
     public const int SC_MAX_MARGIN = 4;
@@ -953,6 +958,10 @@ internal static class NativeMethods
     public const int SCI_FOLDDISPLAYTEXTSETSTYLE = 2701;
     public const int SCI_GETCARETLINEFRAME = 2704;
     public const int SCI_SETCARETLINEFRAME = 2705;
+    public const int SCI_GETSELECTIONLAYER = 2762;
+    public const int SCI_SETSELECTIONLAYER = 2763;
+    public const int SCI_GETCARETLINELAYER = 2764;
+    public const int SCI_SETCARETLINELAYER = 2765;
     public const int SCI_STARTRECORD = 3001;
     public const int SCI_STOPRECORD = 3002;
     public const int SCI_SETLEXER = 4001;

--- a/Shared/Scintilla.cs
+++ b/Shared/Scintilla.cs
@@ -2678,6 +2678,25 @@ namespace ScintillaNET
         }
 
         /// <summary>
+        /// Gets or sets the layer where the text selection will be painted. Default value is <see cref="Layer.Base"/>
+        /// </summary>
+        [DefaultValue(Layer.Base)]
+        [Category("Selection")]
+        [Description("The layer where the text selection will be painted.")]
+        public Layer SelectionLayer
+        {
+            get
+            {
+                return (Layer)DirectMessage(NativeMethods.SCI_GETSELECTIONLAYER).ToInt32();
+            }
+            set
+            {
+                int layer = (int)value;
+                DirectMessage(NativeMethods.SCI_SETSELECTIONLAYER, new IntPtr(layer), IntPtr.Zero);
+            }
+        }
+
+        /// <summary>
         /// Styles the specified length of characters.
         /// </summary>
         /// <param name="length">The number of characters to style.</param>
@@ -4021,6 +4040,25 @@ namespace ScintillaNET
             {
                 var visibleAlways = (value ? new IntPtr(1) : IntPtr.Zero);
                 DirectMessage(NativeMethods.SCI_SETCARETLINEVISIBLEALWAYS, visibleAlways);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the layer where the line caret will be painted. Default value is <see cref="Layer.Base"/>
+        /// </summary>
+        [DefaultValue(Layer.Base)]
+        [Category("Caret")]
+        [Description("The layer where the line caret will be painted.")]
+        public Layer CaretLineLayer
+        {
+            get
+            {
+                return (Layer)DirectMessage(NativeMethods.SCI_GETCARETLINELAYER).ToInt32();
+            }
+            set
+            {
+                int layer = (int)value;
+                DirectMessage(NativeMethods.SCI_SETCARETLINELAYER, new IntPtr(layer));
             }
         }
 


### PR DESCRIPTION
Added Layer enum that groups `SC_LAYER_BASE`, `SC_LAYER_UNDER_TEXT` and `SC_LAYER_OVER_TEXT`. Added properties `SelectionLayer` and `CaretLineLayer` in Scintilla control to set the layer of the text selection and the layer of the currently highlighted line when `CaretLineVisible` is set.

**Note:** one thing that I couldn't get around is the default value of `CaretLineLayer` property. While for a newly created control it reports `Base` or `0`, the behavior is as if `OverText` (or `2`) is selected. This might create confusion but I'm not sure if there is anything to be done as, _if_ there is a bug, that seems to be in the native control side. Perhaps adding `CaretLineLayer = Layer.Base` in the constructor might be enough?

Fixes #24 